### PR TITLE
🐛✅RM#6590-10: Bugfix special characters filename

### DIFF
--- a/oftools_compile/Job.py
+++ b/oftools_compile/Job.py
@@ -92,6 +92,10 @@ class Job(object):
             extension = self._section_name_no_filter
             self._file_name_out = filename + '.' + extension
 
+        if self._file_name_in.startswith(('$', '#', '@')):
+            self._file_name_in = '\\' + self._file_name_in
+            self._file_name_out = '\\' + self._file_name_out
+
     def _update_context(self):
         """Updates Context with the name of files being manipulated in this job execution.
         """

--- a/tests/unit/test_job/asm.prof
+++ b/tests/unit/test_job/asm.prof
@@ -1,0 +1,9 @@
+[setup]
+workdir = /opt/tmaxapp/compile
+
+[ofasmpp]
+$OF_COMPILE_OUT = $OF_COMPILE_BASE.asmi
+args = -i $OF_COMPILE_IN -o $OF_COMPILE_OUT
+
+[ofasma]
+args = -i $OF_COMPILE_IN -o $OF_COMPILE_OUT

--- a/tests/unit/test_job/sources/#sample.asm
+++ b/tests/unit/test_job/sources/#sample.asm
@@ -1,0 +1,5 @@
+#WTO01      CSECT
+            USING     #WTO01,15
+            OFADBGMEM =C'#WTO',2
+            BR        14
+            END

--- a/tests/unit/test_job/sources/$sample.asm
+++ b/tests/unit/test_job/sources/$sample.asm
@@ -1,0 +1,5 @@
+$WTO01      CSECT
+            USING     $WTO01,15
+            OFADBGMEM =C'$WTO',2
+            BR        14
+            END

--- a/tests/unit/test_job/sources/@sample.asm
+++ b/tests/unit/test_job/sources/@sample.asm
@@ -1,0 +1,5 @@
+@WTO01      CSECT
+            USING     @WTO01,15
+            OFADBGMEM =C'@WTO',2
+            BR        14
+            END

--- a/tests/unit/test_job/test_job_file_name.py
+++ b/tests/unit/test_job/test_job_file_name.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Test regarding the Job module about the input file name.
+"""
+
+# Generic/Built-in modules
+import os
+import sys
+
+# Third-party modules
+import pytest
+
+# Owned modules
+from ....oftools_compile.Main import Main
+
+
+class TestJob(object):
+    """A class for all test cases related to special characters in the input file name.
+
+        Fixtures:
+            init_pwd
+
+        Tests:
+            test_dollar_sign
+            test_number_sign
+            test_at_sign
+        """
+
+    @staticmethod
+    @pytest.fixture
+    def init_pwd():
+        """Fixture to initialize the path to the test files.
+            """
+        pwd = os.getcwd() + '/tests/unit/test_job/'
+        return pwd
+
+    @staticmethod
+    def test_dollar_sign(init_pwd):
+        """Test with an input file starting with a $.
+            """
+        sys.argv = [sys.argv[0]]
+        sys.argv.extend(['--log-level', 'DEBUG'])
+        sys.argv.extend(['--profile', init_pwd + 'asm.prof'])
+        sys.argv.extend(['--source', init_pwd + 'sources/$sample.asm'])
+
+        assert Main().run() == 0
+
+    @staticmethod
+    def test_number_sign(init_pwd):
+        """Test with an input file starting with a #.
+            """
+        sys.argv = [sys.argv[0]]
+        sys.argv.extend(['--log-level', 'DEBUG'])
+        sys.argv.extend(['--profile', init_pwd + 'asm.prof'])
+        sys.argv.extend(['--source', init_pwd + 'sources/#sample.asm'])
+
+        assert Main().run() == 0
+
+    @staticmethod
+    def test_at_sign(init_pwd):
+        """Test with an input file starting with a @.
+            """
+        sys.argv = [sys.argv[0]]
+        sys.argv.extend(['--log-level', 'DEBUG'])
+        sys.argv.extend(['--profile', init_pwd + 'asm.prof'])
+        sys.argv.extend(['--source', init_pwd + 'sources/@sample.asm'])
+
+        assert Main().run() == 0


### PR DESCRIPTION
**What:** handling the case where the input filename starts with a special
a character such as $, #, or @.

**Why**: bug-free execution of the program when handling Assembler programs
with special characters.